### PR TITLE
Document more modifiers

### DIFF
--- a/src/auth_on_publish_hook.erl
+++ b/src/auth_on_publish_hook.erl
@@ -1,13 +1,6 @@
 %% @hidden
 -module(auth_on_publish_hook).
--include("vernemq_dev.hrl").
--type msg_modifier() :: {topic, topic()}
-                      | {payload, payload()}
-                      | {reg_view, reg_view()}
-                      | {qos, qos()}
-                      | {retain, flag()}
-                      | {mountpoint, mountpoint()}.
-
+-include("vernemq_dev_int.hrl").
 -callback auth_on_publish(UserName      :: username(),
                           SubscriberId  :: subscriber_id(),
                           QoS           :: qos(),
@@ -18,5 +11,28 @@
                                                       | {ok, Modifiers  :: [msg_modifier()]}
                                                       | {error, Reason  :: any()}
                                                       | next.
+
+-type msg_modifier() ::
+        %% Change the topic of the message.
+        {topic, topic()}
+
+        %% Change the payload of the message.
+      | {payload, payload()}
+
+        %% Change the QoS of the message.
+      | {qos, qos()}
+
+        %% Change the retain flag of the message.
+      | {retain, flag()}
+
+        %% Change the mountpoint where the message is
+        %% published.
+      | {mountpoint, mountpoint()}
+
+        %% Throttle the publisher for a number of
+        %% milliseconds. Note, there is no
+        %% back-pressure for websocket connections.
+      | {throttle, milliseconds()}.
+
 
 -export_type([msg_modifier/0]).

--- a/src/auth_on_publish_m5_hook.erl
+++ b/src/auth_on_publish_m5_hook.erl
@@ -28,12 +28,26 @@
 
 -type msg_modifier() ::
         #{
-           topic => topic(),
-           payload => payload(),
-           reg_view => reg_view(),
-           qos => qos(),
-           retain => flag(),
-           mountpoint => mountpoint()
+          %% Change the topic of the message
+          topic => topic(),
+
+          %% Change the payload of the message.
+          payload => payload(),
+
+          %% Change the QoS of the message.
+          qos => qos(),
+
+          %% Change the retain flag of the message.
+          retain => flag(),
+
+          %% Change the mountpoint where the message is
+          %% published.
+          mountpoint => mountpoint(),
+
+          %% Throttle the publisher for a number of
+          %% milliseconds. Note, there is no
+          %% back-pressure for websocket connections.
+          throttle => milliseconds()
          }.
 
 

--- a/src/auth_on_register_hook.erl
+++ b/src/auth_on_register_hook.erl
@@ -2,10 +2,6 @@
 -module(auth_on_register_hook).
 -include("vernemq_dev.hrl").
 
--type reg_modifiers()   :: {mountpoint, mountpoint()}
-                         | {regview, reg_view()}
-                         | {clean_session, flag()}.
-
 %% called as an all_till_ok hook
 -callback auth_on_register(Peer          :: peer(),
                            SubscriberId  :: subscriber_id(),
@@ -15,5 +11,27 @@
                                                            | {ok, [reg_modifiers()]}
                                                            | {error, invalid_credentials | any()}
                                                            | next.
+-type reg_modifiers()   ::
+        %% Change the mountpoint for the session.
+        {mountpoint, mountpoint()}
+
+        %% Change the if the session should be clean or not.
+      | {clean_session, flag()}
+
+        %% Set the maximum message size the client is allowed to
+        %% publish.
+      | {max_message_size, non_neg_integer()}
+
+        %% Override the global shared subscription policy for this
+        %% session.
+      | {shared_subscription_policy, shared_sub_policy()}
+
+        %% Override the global maximum number of online messages for
+        %% this session.
+      | {max_online_messages, non_neg_integer()}
+
+        %% Override the global maximum number of offline messages
+        %% for this session.
+      | {max_offline_messages, non_neg_integer()}.
 
 -export_type([reg_modifiers/0]).

--- a/src/auth_on_register_m5_hook.erl
+++ b/src/auth_on_register_m5_hook.erl
@@ -29,12 +29,28 @@
 
 -type reg_modifiers()   ::
         #{
-           clean_start => flag(),
-           max_message_size => non_neg_integer(),
-           subscriber_id => subscriber_id(),
-           shared_subscription_policy => shared_sub_policy(),
-           max_online_messages => non_neg_integer(),
-           max_offline_messages => non_neg_integer()
+          %% Change the mountpoint for the session.
+          mountpoint => mountpoint(),
+
+          %% Override the `clean_start` value.
+          clean_start => flag(),
+
+          %% Set the maximum message size the client is allowed to
+          %% publish.
+          max_message_size => non_neg_integer(),
+
+          %% Override the global shared subscription policy for this
+          %% session.
+          shared_subscription_policy => shared_sub_policy(),
+
+          %% Override the global maximum number of online messages for
+          %% this session.
+          max_online_messages => non_neg_integer(),
+
+
+          %% Override the global maximum number of offline messages
+          %% for this session.
+          max_offline_messages => non_neg_integer()
          }.
 
 -type err_reason_code_name() :: ?UNSPECIFIED_ERROR

--- a/src/auth_on_subscribe_hook.erl
+++ b/src/auth_on_subscribe_hook.erl
@@ -5,7 +5,14 @@
 %% called as an all_till_ok - hook
 -callback auth_on_subscribe(UserName      :: username(),
                             SubscriberId  :: subscriber_id(),
-                            Topics        :: [{Topic :: topic(), QoS :: qos()}]) -> ok
-                                                                                  | {ok, [{Topic :: topic(), Qos :: qos()}]}
-                                                                                  | {error, Reason :: any()}
-                                                                                  | next.
+                            Topics        :: [{Topic :: topic(), QoS :: qos()}]) ->
+    ok |
+    {ok, sub_modifiers()} |
+    {error, Reason :: any()} |
+    next.
+
+-type sub_modifiers() ::
+        %% Change the topics which will be subscribed.
+        [{Topic :: topic(), Qos :: qos()}].
+
+-export_type([sub_modifiers/0]).

--- a/src/auth_on_subscribe_m5_hook.erl
+++ b/src/auth_on_subscribe_m5_hook.erl
@@ -20,7 +20,8 @@
 
 -type sub_modifiers() ::
         #{
-           topics => [{Topic :: topic(), SubInfo :: subinfo()}]
+          %% Change the topics which will be subscribed.
+          topics => [{Topic :: topic(), SubInfo :: subinfo()}]
          }.
 
 -export_type([sub_modifiers/0]).

--- a/src/on_auth_m5_hook.erl
+++ b/src/on_auth_m5_hook.erl
@@ -22,8 +22,10 @@
            %% Indicate towards the client if the authentication was
            %% successful or should be continued.
            reason_code => ?SUCCESS | ?CONTINUE_AUTHENTICATION,
+
            %% Specify the authentication method to send to the client.
            auth_method => binary(),
+
            %% Specify the authentication data to send to the client.
            auth_data => binary()
          }.

--- a/src/on_deliver_hook.erl
+++ b/src/on_deliver_hook.erl
@@ -1,8 +1,6 @@
 %% @hidden
 -module(on_deliver_hook).
 -include("vernemq_dev.hrl").
--type msg_modifier() :: {topic, topic()}
-                      | {payload, payload()}.
 
 -callback on_deliver(UserName      :: username(),
                      SubscriberId  :: subscriber_id(),
@@ -11,5 +9,13 @@
                                                     | {ok, Payload    :: payload()}
                                                     | {ok, Modifiers  :: [msg_modifier()]}
                                                     | next.
+
+-type msg_modifier() ::
+        %% Rewrite the topic of the message.
+        {topic, topic()}
+
+        %% Rewrite the payload of the message.
+      | {payload, payload()}.
+
 
 -export_type([msg_modifier/0]).

--- a/src/on_deliver_m5_hook.erl
+++ b/src/on_deliver_m5_hook.erl
@@ -26,8 +26,11 @@
 
 -type msg_modifier() ::
         #{
-           topic => topic(),
-           payload => payload()
+          %% Rewrite the topic of the message.
+          topic => topic(),
+
+          %% Rewrite the payload of the message.
+          payload => payload()
          }.
 
 -export_type([msg_modifier/0]).

--- a/src/on_unsubscribe_hook.erl
+++ b/src/on_unsubscribe_hook.erl
@@ -5,6 +5,11 @@
 %% called as an 'all'-hook, return value is ignored
 -callback on_unsubscribe(UserName      :: username(),
                          SubscriberId  :: subscriber_id(),
-                         Topics        :: [Topic :: topic()]) -> ok
-                                                                 | {ok, [Topic :: topic()]}
-                                                                 | next.
+                         Topics        :: [Topic :: topic()]) ->
+    ok |
+    {ok, unsub_modifiers()} |
+    next.
+
+-type unsub_modifiers() ::
+        %% Change the topics which will be unsubscribed.
+        [Topic :: topic()].

--- a/src/on_unsubscribe_m5_hook.erl
+++ b/src/on_unsubscribe_m5_hook.erl
@@ -18,5 +18,6 @@
 
 -type unsub_modifiers() ::
         #{
-           topics => [topic()]
+          %% Change the topics which will be unsubscribed.
+          topics => [topic()]
          }.

--- a/src/vernemq_dev_int.hrl
+++ b/src/vernemq_dev_int.hrl
@@ -1,6 +1,7 @@
 -include("vernemq_dev.hrl").
 
 -type utf8string() :: binary().
+-type milliseconds() :: non_neg_integer().
 -type seconds() :: non_neg_integer().
 -type user_property() :: {utf8string(), utf8string()}.
 -type subscription_id() :: 1..268435455.


### PR DESCRIPTION
Document existing hooks.

Note I removed the `reg_view` hook as I think it's really too complex and rarely used. Let me know if I should add it back.


Next up: document mqtt5 specific hooks: session_expiration and message_expiration to name a few (this will need a bit of cleanup in `vmq_plugin_util:check_modifiers` function.
