### PR TITLE
Fix force disconnect

### DIFF
--- a/src/vernemq_dev_api.erl
+++ b/src/vernemq_dev_api.erl
@@ -32,7 +32,7 @@ disconnect_by_subscriber_id(SubscriberId, Opts) ->
         not_found ->
             not_found;
         QueuePid ->
-            vmq_queue:force_disconnect(QueuePid, proplists:get_bool(do_cleanup, Opts))
+            vmq_queue:force_disconnect(QueuePid, normal, proplists:get_bool(do_cleanup, Opts))
     end.
 
 %% @doc Convert a {@link topic().} list into an {@link iolist().}


### PR DESCRIPTION
We have to use `vmq_queue:force_disconnect/3` to be able to pass
options.