### PR TITLE
Mqtt5 properties rework

### DIFF
--- a/src/auth_on_publish_m5_hook.erl
+++ b/src/auth_on_publish_m5_hook.erl
@@ -49,21 +49,24 @@
           %% back-pressure for websocket connections.
           throttle => milliseconds(),
 
-          %% Override the message expiry from the properties or set it
-          %% if not present.
-          message_expiry_interval => seconds(),
+          properties =>
+              #{
+                %% Override the message expiry from the properties or set it
+                %% if not present.
+                p_message_expiry_interval => seconds(),
 
-          %% Override the user properties from the properties or set
-          %% them if not present.
-          user_property => [user_property()],
+                %% Override the user properties from the properties or set
+                %% them if not present.
+                p_user_property => [user_property()],
 
-          %% Override the response topic from the properties or set if
-          %% not present.
-          response_topic => topic(),
+                %% Override the response topic from the properties or set if
+                %% not present.
+                p_response_topic => topic(),
 
-          %% Override the correlation data from the properties or set
-          %% if not present.
-          correlation_data => binary()
+                %% Override the correlation data from the properties or set
+                %% if not present.
+                p_correlation_data => binary()
+               }
          }.
 
 

--- a/src/auth_on_publish_m5_hook.erl
+++ b/src/auth_on_publish_m5_hook.erl
@@ -55,7 +55,15 @@
 
           %% Override the user properties from the properties or set
           %% them if not present.
-          user_property => [user_property()]
+          user_property => [user_property()],
+
+          %% Override the response topic from the properties or set if
+          %% not present.
+          response_topic => topic(),
+
+          %% Override the correlation data from the properties or set
+          %% if not present.
+          correlation_data => binary()
          }.
 
 

--- a/src/auth_on_publish_m5_hook.erl
+++ b/src/auth_on_publish_m5_hook.erl
@@ -23,7 +23,7 @@
           p_response_topic => topic(),
           p_correlation_data => binary(),
           p_topic_alias => 1..65535,
-          p_user_property => [user_property()]
+          p_user_property => nonempty_list(user_property())
          }.
 
 -type msg_modifier() ::
@@ -51,13 +51,19 @@
 
           properties =>
               #{
+                %% Override the payload format indicator
+                p_payload_format_indicator => unspecified | utf8,
+
+                %% Override the content type
+                p_content_type => utf8string(),
+
                 %% Override the message expiry from the properties or set it
                 %% if not present.
                 p_message_expiry_interval => seconds(),
 
                 %% Override the user properties from the properties or set
                 %% them if not present.
-                p_user_property => [user_property()],
+                p_user_property => nonempty_list(user_property()),
 
                 %% Override the response topic from the properties or set if
                 %% not present.

--- a/src/auth_on_register_m5_hook.erl
+++ b/src/auth_on_register_m5_hook.erl
@@ -52,9 +52,11 @@
           %% for this session.
           max_offline_messages => non_neg_integer(),
 
-          %% Override the session expiry from the properties or set it
-          %% if not present.
-          session_expiry_interval => seconds()
+          properties => #{
+                          %% Override the session expiry from the
+                          %% properties or set it if not present.
+                          p_session_expiry_interval => seconds()
+                         }
          }.
 
 -type err_reason_code_name() :: ?UNSPECIFIED_ERROR

--- a/src/auth_on_register_m5_hook.erl
+++ b/src/auth_on_register_m5_hook.erl
@@ -24,7 +24,7 @@
           p_max_packet_size => 1..4294967296,
           p_request_response_info => boolean(),
           p_request_problem_info => boolean(),
-          p_user_property => [user_property()]
+          p_user_property => nonempty_list(user_property())
          }.
 
 -type reg_modifiers()   ::

--- a/src/auth_on_subscribe_m5_hook.erl
+++ b/src/auth_on_subscribe_m5_hook.erl
@@ -15,7 +15,7 @@
 -type sub_properties() ::
         #{
           p_subscription_id => [subscription_id()],
-          p_user_property => [user_property()]
+          p_user_property => nonempty_list(user_property())
          }.
 
 -type sub_modifiers() ::

--- a/src/on_auth_m5_hook.erl
+++ b/src/on_auth_m5_hook.erl
@@ -13,21 +13,24 @@
 
 -type auth_properties() ::
         #{
-          p_authentication_method => utf8string(),
-          p_authentication_data => binary()
+          p_authentication_method := utf8string(),
+          p_authentication_data := binary()
          }.
 
 -type auth_modifiers() ::
         #{
-           %% Indicate towards the client if the authentication was
-           %% successful or should be continued.
-           reason_code => ?SUCCESS | ?CONTINUE_AUTHENTICATION,
+          %% Indicate towards the client if the authentication was
+          %% successful or should be continued.
+          reason_code => ?SUCCESS | ?CONTINUE_AUTHENTICATION,
 
-           %% Specify the authentication method to send to the client.
-           auth_method => binary(),
+          properties :=
+                #{
+                  %% Specify the authentication method to send to the client.
+                  p_authentication_method := binary(),
 
-           %% Specify the authentication data to send to the client.
-           auth_data => binary()
+                  %% Specify the authentication data to send to the client.
+                  p_authentication_data := binary()
+                 }
          }.
 
 -type err_values() ::

--- a/src/on_deliver_m5_hook.erl
+++ b/src/on_deliver_m5_hook.erl
@@ -5,8 +5,8 @@
 -callback on_deliver_m5(UserName      :: username(),
                         SubscriberId  :: subscriber_id(),
                         Topic         :: topic(),
-                        Properties    :: deliver_properties(),
-                        Payload       :: payload()) ->
+                        Payload       :: payload(),
+                        Properties    :: deliver_properties()) ->
     ok |
     {ok, Payload    :: payload()} |
     {ok, Modifiers  :: msg_modifier()} |

--- a/src/on_deliver_m5_hook.erl
+++ b/src/on_deliver_m5_hook.erl
@@ -30,7 +30,21 @@
           topic => topic(),
 
           %% Rewrite the payload of the message.
-          payload => payload()
+          payload => payload(),
+
+          properties => #{
+                          %% Override the user properties from the properties or set
+                          %% them if not present.
+                          p_user_property => [user_property()],
+
+                          %% Override the response topic from the properties or set if
+                          %% not present.
+                          p_response_topic => topic(),
+
+                          %% Override the correlation data from the properties or set
+                          %% if not present.
+                          p_correlation_data => binary()
+                         }
          }.
 
 -export_type([msg_modifier/0]).

--- a/src/on_deliver_m5_hook.erl
+++ b/src/on_deliver_m5_hook.erl
@@ -8,7 +8,6 @@
                         Payload       :: payload(),
                         Properties    :: deliver_properties()) ->
     ok |
-    {ok, Payload    :: payload()} |
     {ok, Modifiers  :: msg_modifier()} |
     next.
 
@@ -19,7 +18,7 @@
           p_topic_alias => 1..65535,
           p_response_topic => topic(),
           p_correlation_data => binary(),
-          p_user_property => [user_property()],
+          p_user_property => nonempty_list(user_property()),
           p_subscription_id => [subscription_id()],
           p_content_type => utf8string()
          }.
@@ -32,19 +31,26 @@
           %% Rewrite the payload of the message.
           payload => payload(),
 
-          properties => #{
-                          %% Override the user properties from the properties or set
-                          %% them if not present.
-                          p_user_property => [user_property()],
+          properties =>
+              #{
+                %% Override the payload format indicator
+                p_payload_format_indicator => unspecified | utf8,
 
-                          %% Override the response topic from the properties or set if
-                          %% not present.
-                          p_response_topic => topic(),
+                %% Override the content type
+                p_content_type => utf8string(),
 
-                          %% Override the correlation data from the properties or set
-                          %% if not present.
-                          p_correlation_data => binary()
-                         }
+                %% Override the user properties from the properties or set
+                %% them if not present.
+                p_user_property => nonempty_list(user_property()),
+
+                %% Override the response topic from the properties or set if
+                %% not present.
+                p_response_topic => topic(),
+
+                %% Override the correlation data from the properties or set
+                %% if not present.
+                p_correlation_data => binary()
+               }
          }.
 
 -export_type([msg_modifier/0]).

--- a/src/on_unsubscribe_m5_hook.erl
+++ b/src/on_unsubscribe_m5_hook.erl
@@ -13,7 +13,7 @@
 
 -type unsub_properties() ::
         #{
-          p_user_property => [user_property()]
+          p_user_property => nonempty_list(user_property())
          }.
 
 -type unsub_modifiers() ::


### PR DESCRIPTION
This PR does two things:

1. it separates all properties from other modifiers and embeds them in a new modifier entry `properties => #{...}`. This is so it is possible to drop properties, for example by returning the modifier `properties => #{}`.
2. All property modifiers are now using the `p_` prefixed names (just as the properties in the hook arguments). So for example `user_property` is now `p_user_property`