### PR TITLE
Update on_deliver* and add new `on_session_expired` hook

### DIFF
--- a/src/on_deliver_hook.erl
+++ b/src/on_deliver_hook.erl
@@ -4,18 +4,26 @@
 
 -callback on_deliver(UserName      :: username(),
                      SubscriberId  :: subscriber_id(),
+                     QoS           :: qos(),
                      Topic         :: topic(),
-                     Payload       :: payload()) -> ok
-                                                    | {ok, Payload    :: payload()}
-                                                    | {ok, Modifiers  :: [msg_modifier()]}
-                                                    | next.
+                     Payload       :: payload(),
+                     IsRetain      :: flag()) -> ok
+                                                 | {ok, Payload    :: payload()}
+                                                 | {ok, Modifiers  :: [msg_modifier()]}
+                                                 | next.
 
 -type msg_modifier() ::
         %% Rewrite the topic of the message.
         {topic, topic()}
 
         %% Rewrite the payload of the message.
-      | {payload, payload()}.
+      | {payload, payload()}
+
+        %% Rewrite the QoS of the message.
+      | {qos, qos()}
+
+        %% Rewrite the retain flag of the message.
+      | {retain, flag()}.
 
 
 -export_type([msg_modifier/0]).

--- a/src/on_deliver_m5_hook.erl
+++ b/src/on_deliver_m5_hook.erl
@@ -4,8 +4,10 @@
 
 -callback on_deliver_m5(UserName      :: username(),
                         SubscriberId  :: subscriber_id(),
+                        QoS           :: qos(),
                         Topic         :: topic(),
                         Payload       :: payload(),
+                        IsRetain      :: flag(),
                         Properties    :: deliver_properties()) ->
     ok |
     {ok, Modifiers  :: msg_modifier()} |
@@ -30,6 +32,12 @@
 
           %% Rewrite the payload of the message.
           payload => payload(),
+
+          %% Rewrite the QoS of the message.
+          qos => qos(),
+
+          %% Rewrite the retain flag of the message.
+          retain => flag(),
 
           properties =>
               #{

--- a/src/on_session_expired_hook.erl
+++ b/src/on_session_expired_hook.erl
@@ -1,0 +1,6 @@
+%% @hidden
+-module(on_session_expired_hook).
+-include("vernemq_dev.hrl").
+
+%% called as an 'all' hook, return value is ignored
+-callback on_session_expired(SubscriberId  :: subscriber_id()) -> any().


### PR DESCRIPTION
Add new `on_deliver*` hook variant to include QoS and Retained flag modifiers and new `on_session_expired` hook.

Part of https://github.com/vernemq/vernemq/issues/1346