### PR TITLE
WIP: Add macros for using the OTP 21.0+ logger

### DIFF
--- a/include/vernemq_logger.hrl
+++ b/include/vernemq_logger.hrl
@@ -1,0 +1,24 @@
+-ifndef(VERNEMQ_LOGGER_HRL).
+-define(VERNEMQ_LOGGER_HRL, true).
+
+-include_lib("kernel/include/logger.hrl").
+
+-define(LOG_IF(Level, Condition, Format, Args),
+    (Condition) == true andalso ?LOG(Level, Format, Args)).
+
+-define(DEBUG_MSG(Format, Args),
+    ?LOG_DEBUG(Format, Args)).
+
+-define(INFO_MSG(Format, Args),
+    ?LOG_INFO(Format, Args)).
+
+-define(WARNING_MSG(Format, Args),
+    ?LOG_WARNING(Format, Args)).
+
+-define(ERROR_MSG(Format, Args),
+    ?LOG_ERROR(Format, Args)).
+
+-define(CRITICAL_MSG(Format, Args),
+    ?LOG_CRITICAL(Format, Args)).
+
+-endif.


### PR DESCRIPTION
This is part of an evil plan to transition from lager to the OTP 21.0 logger as the VerneMQ logging framework.

**But why, what does logger can offer?**

* Structured logs including JSON logs (container and DevOps people love these)
* overload protection mechanisms
* default logs metadata
* one less dependency to worry about, and in the future `lager` plans to default to the logger
* plugins don't have to include lager, when I was developing plugins had problems a few times from using a different lager version than VerneMQ had

More info at https://ferd.ca/erlang-otp-21-s-new-logger.html

Upcoming series of PRs coming to other Verne Repos and documentation.